### PR TITLE
Test error handling at the resource level to prevent duplicate tests

### DIFF
--- a/lib/stannp/resource.rb
+++ b/lib/stannp/resource.rb
@@ -14,14 +14,6 @@ module Stannp
       handle_response client.connection.post(url, body, headers)
     end
 
-    def patch_request(url, body:, headers: {})
-      handle_response client.connection.patch(url, body, headers)
-    end
-
-    def put_request(url, body:, headers: {})
-      handle_response client.connection.put(url, body, headers)
-    end
-
     private
 
     attr_reader :client

--- a/spec/stannp/resource_spec.rb
+++ b/spec/stannp/resource_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'faraday'
+
+RSpec.describe Stannp::Resource do
+  let(:api_key) { 'test' }
+  let(:stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:client) { Stannp::Client.new(api_key: api_key, adapter: :test, stubs: stubs) }
+  let(:resource) { Stannp::Resource.new(client: client) }
+
+  describe '#get_request' do
+    let(:url) { "https://dash.stannp.com/api/v1/users/me?api_key=#{api_key}" }
+
+    context 'with a successful request' do
+      let(:response_code) { 200 }
+      let(:body)          { json_response({ success: true }) }
+
+      before(:each) do
+        stubs.get(url) { |_| [response_code, {}, body] }
+      end
+  
+      it 'returns the correct rrsponse' do
+        response = resource.get_request(url)
+        expect(response.body).to eql(body)
+      end
+    end
+
+    context 'with a failing request' do
+      let(:response_code) { 400 }
+      let(:body)          { json_response({ error: 'Oh No!' }) }
+      let(:url)           { "https://dash.stannp.com/api/v1/users/me?api_key=#{api_key}" }
+
+      before(:each) do
+        stubs.get(url) { |_| [response_code, {}, body] }
+      end
+  
+      it 'raises an error' do
+        expect{ resource.get_request(url) }.to raise_error(Stannp::Error, '400: Oh No!')
+      end
+    end
+  end
+
+  describe '#post_request' do
+    let(:url) { "https://dash.stannp.com/api/v1/users/me?api_key=#{api_key}" }
+
+    context 'with a successful request' do
+      let(:response_code) { 200 }
+      let(:body)          { json_response({ success: true }) }
+
+      before(:each) do
+        stubs.post(url) { |_| [response_code, {}, body] }
+      end
+  
+      it 'returns the correct rrsponse' do
+        response = resource.post_request(url, body: { id: 1 })
+        expect(response.body).to eql(body)
+      end
+    end
+
+    context 'with a failing request' do
+      let(:response_code) { 400 }
+      let(:body)          { json_response({ error: 'Oh No!' }) }
+      let(:url)           { "https://dash.stannp.com/api/v1/users/me?api_key=#{api_key}" }
+
+      before(:each) do
+        stubs.post(url) { |_| [response_code, {}, body] }
+      end
+  
+      it 'raises an error' do
+        expect{ resource.post_request(url, body: { id: 1 }) }.to raise_error(Stannp::Error, '400: Oh No!')
+      end
+    end
+  end
+end

--- a/spec/stannp/resources/account_spec.rb
+++ b/spec/stannp/resources/account_spec.rb
@@ -13,22 +13,11 @@ RSpec.describe Stannp::AccountResource do
       stubs.get("https://dash.stannp.com/api/v1/accounts/balance?api_key=#{client.api_key}}") { |_| [response_code, {}, body] }
     end
 
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) { json_response({ data: { balance: '100.59' } }) }
+    let(:response_code) { 200 }
+    let(:body) { json_response({ data: { balance: '100.59' } }) }
 
-      it 'returns the account balance' do
-        expect(client.account.balance).to eql('100.59')
-      end
-    end
-
-    context 'with a failing request' do
-      let(:response_code) { 500 }
-      let(:body) { json_response({ error: 'Server says no!' }) }
-
-      it 'returns an error' do
-        expect { client.account.balance }.to raise_error(Stannp::Error, '500: Server says no!')
-      end
+    it 'returns the account balance' do
+      expect(client.account.balance).to eql('100.59')
     end
   end
 
@@ -37,26 +26,13 @@ RSpec.describe Stannp::AccountResource do
       stubs.post("https://dash.stannp.com/api/v1/accounts/topup?api_key=#{client.api_key}}") { |_| [response_code, {}, body] }
     end
 
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) { json_response({ data: { receipt_pdf: '/path/to/pdf' } }) }
+    let(:response_code) { 200 }
+    let(:body) { json_response({ data: { receipt_pdf: '/path/to/pdf' } }) }
 
-      it 'returns a receipt' do
-        receipt = client.account.top_up(amount: 10)
-        expect(receipt.class).to eql(Stannp::Receipt)
-        expect(receipt.url).to eql('/path/to/pdf')
-      end
-    end
-
-    context 'with a failing request' do
-      context 'with a failing request' do
-        let(:response_code) { 500 }
-        let(:body) { json_response({ error: 'Server says no!' }) }
-
-        it 'returns an error' do
-          expect { client.account.top_up(amount: 10) }.to raise_error(Stannp::Error, '500: Server says no!')
-        end
-      end
+    it 'returns a receipt' do
+      receipt = client.account.top_up(amount: 10)
+      expect(receipt.class).to eql(Stannp::Receipt)
+      expect(receipt.url).to eql('/path/to/pdf')
     end
   end
 end

--- a/spec/stannp/resources/recipients_spec.rb
+++ b/spec/stannp/resources/recipients_spec.rb
@@ -9,176 +9,113 @@ RSpec.describe Stannp::RecipientsResource do
   let(:client) { Stannp::Client.new(api_key: api_key, adapter: :test, stubs: stubs) }
 
   describe '#list' do
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) do
-        json_response(
-          {
-            data: [{ id: 1, name: 'Bob Smith' }, { id: 2, name: 'Jane Smith' }]
-          }
-        )
-      end
-
-      context 'without a group_id' do
-        before(:each) do
-          stubs.get("https://dash.stannp.com/api/v1/recipients/list?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-        end
-
-        it 'returns a list of recipients' do
-          list = client.recipients.list
-          data = list.data
-
-          expect(list.class).to eql(Stannp::List)
-          expect(data.length).to eql(2)
-
-          bob = data.first
-          expect(bob.class).to eql(Stannp::Recipient)
-          expect(bob.id).to eql(1)
-          expect(bob.name).to eql('Bob Smith')
-
-          jane = data.last
-          expect(jane.class).to eql(Stannp::Recipient)
-          expect(jane.id).to eql(2)
-          expect(jane.name).to eql('Jane Smith')
-        end
-      end
-
-      context 'with a group_id' do
-        before(:each) do
-          stubs.get("https://dash.stannp.com/api/v1/recipients/list/1234?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-        end
-  
-        before(:each) do
-          stubs.get("https://dash.stannp.com/api/v1/recipients/list?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-        end
-
-        it 'returns a list of recipients' do
-          list = client.recipients.list(group_id: 1234)
-          data = list.data
-
-          expect(list.class).to eql(Stannp::List)
-          expect(data.length).to eql(2)
-
-          bob = data.first
-          expect(bob.class).to eql(Stannp::Recipient)
-          expect(bob.id).to eql(1)
-          expect(bob.name).to eql('Bob Smith')
-
-          jane = data.last
-          expect(jane.class).to eql(Stannp::Recipient)
-          expect(jane.id).to eql(2)
-          expect(jane.name).to eql('Jane Smith')
-        end
-      end
+    let(:response_code) { 200 }
+    let(:body) do
+      json_response(
+        {
+          data: [{ id: 1, name: 'Bob Smith' }, { id: 2, name: 'Jane Smith' }]
+        }
+      )
     end
 
-    context 'with a failing request' do
-      let(:response_code) { 500 }
-      let(:body) { json_response({ error: 'Boom!' }) }
-  
+    context 'without a group_id' do
       before(:each) do
         stubs.get("https://dash.stannp.com/api/v1/recipients/list?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
       end
-  
-      it 'returns an error' do
-        expect { client.recipients.list }.to raise_error(Stannp::Error, '500: Boom!')
+
+      it 'returns a list of recipients' do
+        list = client.recipients.list
+        data = list.data
+
+        expect(list.class).to eql(Stannp::List)
+        expect(data.length).to eql(2)
+
+        bob = data.first
+        expect(bob.class).to eql(Stannp::Recipient)
+        expect(bob.id).to eql(1)
+        expect(bob.name).to eql('Bob Smith')
+
+        jane = data.last
+        expect(jane.class).to eql(Stannp::Recipient)
+        expect(jane.id).to eql(2)
+        expect(jane.name).to eql('Jane Smith')
       end
     end
-  
+
+    context 'with a group_id' do
+      before(:each) do
+        stubs.get("https://dash.stannp.com/api/v1/recipients/list/1234?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
+      end
+
+      before(:each) do
+        stubs.get("https://dash.stannp.com/api/v1/recipients/list?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
+      end
+
+      it 'returns a list of recipients' do
+        list = client.recipients.list(group_id: 1234)
+        data = list.data
+
+        expect(list.class).to eql(Stannp::List)
+        expect(data.length).to eql(2)
+
+        bob = data.first
+        expect(bob.class).to eql(Stannp::Recipient)
+        expect(bob.id).to eql(1)
+        expect(bob.name).to eql('Bob Smith')
+
+        jane = data.last
+        expect(jane.class).to eql(Stannp::Recipient)
+        expect(jane.id).to eql(2)
+        expect(jane.name).to eql('Jane Smith')
+      end
+    end
   end
 
   describe '#get' do
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) do
-        json_response({ data: { id: 1, name: 'Bob Smith' } })
-      end
-
-      before(:each) do
-        stubs.get("https://dash.stannp.com/api/v1/recipients/get/1?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-      end
-
-      it 'returns a recipient' do
-        recipient = client.recipients.get(id: 1)
-        expect(recipient.class).to eql(Stannp::Recipient)
-        expect(recipient.id).to eql(1)
-        expect(recipient.name).to eql('Bob Smith')
-      end
+    let(:response_code) { 200 }
+    let(:body) do
+      json_response({ data: { id: 1, name: 'Bob Smith' } })
     end
 
-    context 'with a failing request' do
-      let(:response_code) { 500 }
-      let(:body) { json_response({ error: 'Boom!' }) }
-  
-      before(:each) do
-        stubs.get("https://dash.stannp.com/api/v1/recipients/get/1?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-      end
-  
-      it 'returns an error' do
-        expect { client.recipients.get(id: 1) }.to raise_error(Stannp::Error, '500: Boom!')
-      end
+    before(:each) do
+      stubs.get("https://dash.stannp.com/api/v1/recipients/get/1?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
+    end
+
+    it 'returns a recipient' do
+      recipient = client.recipients.get(id: 1)
+      expect(recipient.class).to eql(Stannp::Recipient)
+      expect(recipient.id).to eql(1)
+      expect(recipient.name).to eql('Bob Smith')
     end
   end
 
   describe '#create' do
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) do
-        json_response({ data: { id: 1, valid: true } })
-      end
-
-      before(:each) do
-        stubs.post("https://dash.stannp.com/api/v1/recipients/new?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-      end
-
-      it 'returns a recipient' do
-        recipient = client.recipients.create(attributes: { firstname: 'Bob' })
-        expect(recipient.class).to eql(Stannp::Recipient)
-        expect(recipient.id).to eql(1)
-      end
+    let(:response_code) { 200 }
+    let(:body) do
+      json_response({ data: { id: 1, valid: true } })
     end
 
-    context 'with a failing request' do
-      context 'with a failing request' do
-        let(:response_code) { 500 }
-        let(:body) { json_response({ error: 'Boom!' }) }
-    
-        before(:each) do
-          stubs.post("https://dash.stannp.com/api/v1/recipients/new?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-        end
-    
-        it 'returns an error' do
-          expect { client.recipients.create(attributes: { firstname: 'Foo' }) }.to raise_error(Stannp::Error, '500: Boom!')
-        end
-      end
+    before(:each) do
+      stubs.post("https://dash.stannp.com/api/v1/recipients/new?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
+    end
+
+    it 'returns a recipient' do
+      recipient = client.recipients.create(attributes: { firstname: 'Bob' })
+      expect(recipient.class).to eql(Stannp::Recipient)
+      expect(recipient.id).to eql(1)
     end
   end
 
   describe '#delete' do
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) { json_response({ success: true }) }
+    let(:response_code) { 200 }
+    let(:body) { json_response({ success: true }) }
 
-      before(:each) do
-        stubs.post("https://dash.stannp.com/api/v1/recipients/delete?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-      end
-
-      it 'returns a recipient' do
-        expect(client.recipients.delete(id: 1)).to eql(true)
-      end
+    before(:each) do
+      stubs.post("https://dash.stannp.com/api/v1/recipients/delete?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
     end
 
-    context 'with a failing request' do
-      let(:response_code) { 500 }
-      let(:body) { json_response({ error: 'Boom!' }) }
-
-      before(:each) do
-        stubs.post("https://dash.stannp.com/api/v1/recipients/delete?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-      end
-
-      it 'returns an error' do
-        expect { client.recipients.delete(id: 1) }.to raise_error(Stannp::Error, '500: Boom!')
-      end
+    it 'returns a recipient' do
+      expect(client.recipients.delete(id: 1)).to eql(true)
     end
   end
 
@@ -193,19 +130,6 @@ RSpec.describe Stannp::RecipientsResource do
 
       it 'returns true' do
         expect(client.recipients.delete_all).to eql(true)
-      end
-    end
-
-    context 'with a failing request' do
-      let(:response_code) { 500 }
-      let(:body) { json_response({ error: 'Boom!' }) }
-
-      before(:each) do
-        stubs.post("https://dash.stannp.com/api/v1/recipients/deleteAll?api_key=#{client.api_key}") { |_| [response_code, {}, body] }
-      end
-
-      it 'returns an error' do
-        expect { client.recipients.delete_all }.to raise_error(Stannp::Error, '500: Boom!')
       end
     end
 

--- a/spec/stannp/resources/user_spec.rb
+++ b/spec/stannp/resources/user_spec.rb
@@ -13,24 +13,13 @@ RSpec.describe Stannp::UserResource do
       stubs.get("https://dash.stannp.com/api/v1/users/me?api_key=#{api_key}") { |_| [response_code, {}, body] }
     end
 
-    context 'with a successful request' do
-      let(:response_code) { 200 }
-      let(:body) { json_response({ data: { name: 'Foo' } }) }
+    let(:response_code) { 200 }
+    let(:body) { json_response({ data: { name: 'Foo' } }) }
 
-      it 'returns the user' do
-        user = client.user.get
-        expect(user.class).to eql(Stannp::User)
-        expect(user.name).to eql('Foo')
-      end
-    end
-
-    context 'with an unsuccessful request' do
-      let(:response_code) { 403 }
-      let(:body) { JSON.parse({ error: 'Bang!' }.to_json) }
-
-      it 'raises an error' do
-        expect { client.user.get }.to raise_error(Stannp::Error, '403: Bang!')
-      end
+    it 'returns the user' do
+      user = client.user.get
+      expect(user.class).to eql(Stannp::User)
+      expect(user.name).to eql('Foo')
     end
   end
 end


### PR DESCRIPTION
Remove repetitive tests for error handling and consolidate them to two specs on the Resource model